### PR TITLE
Use spreedly test credentials from spreedly-gem ruby gem repo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ scalaVersion := "2.11.7"
 
 organization := "com.ticketfly"
 
-version := "1.1.0"
+version := "1.1.1"
 
 parallelExecution in Test := false   // Prevents sbt to execute tests in parallel
 fork in Test := true                 // Forks the JVM during tests to prevent sbt OOM error

--- a/src/test/scala/com/ticketfly/spreedly/fixtures/TestCredentials.scala
+++ b/src/test/scala/com/ticketfly/spreedly/fixtures/TestCredentials.scala
@@ -1,10 +1,8 @@
 package com.ticketfly.spreedly.fixtures
 
 object TestCredentials {
-  val environmentKey = "YrIGemJ81cpvbjRg9ZXOBPUjOAb"
-  val accessSecret = "JtGbXng2ZsF4nparVKaFK0r65PvHGCDIFixd1us5EFFScZatMVTJK6zb54V2sb1U"
-
-  // From https://github.com/spreedly/spreedly-gem/tree/master/test/unit
-  //val environmentKey = "R7lHscqcYkZeDGGbthKp6GKMu15"
-  //val accessSecret = "8sefxO5Q44sLWpmZpalQS3Qlqo03JbCemsqsWJR3YOLCuigOFRlaLSAn0WaL5dWU"
+  // Test credentials taken from Spreedly's spreedly-gem tests
+  // https://github.com/spreedly/spreedly-gem/blob/3c8802b3165bdd1ae039692f77dfb254319cccb8/test/credentials/credentials.yml
+  val environmentKey = "R7lHscqcYkZeDGGbthKp6GKMu15"
+  val accessSecret = "8sefxO5Q44sLWpmZpalQS3Qlqo03JbCemsqsWJR3YOLCuigOFRlaLSAn0WaL5dWU"
 }


### PR DESCRIPTION
There was a test environment created specifically for the repo/package, and it used these credentials to run tests.   Instead, use the credentials [provided by Spreedly in their spreedly-gem](https://github.com/spreedly/spreedly-gem/blob/master/test/credentials/credentials.yml) for testing .   Has no effect on the usage of the compiled jar.